### PR TITLE
dmenu style argument parser

### DIFF
--- a/xmenu.1
+++ b/xmenu.1
@@ -6,6 +6,20 @@ xmenu \- menu utility for X
 .RB [ \-iw ]
 .RB [ -p
 .IR position ]
+.RB [ \-fn
+.IR font ]
+.RB [ \-nb
+.IR color ]
+.RB [ \-nf
+.IR color ]
+.RB [ \-sb
+.IR color ]
+.RB [ \-sf
+.IR color ]
+.RB [ \-bc
+.IR color ]
+.RB [ \-sp
+.IR color ]
 .RI [ title ]
 .SH DESCRIPTION
 .B xmenu
@@ -19,6 +33,30 @@ The options are as follows:
 .B -i
 Disable icons.
 This makes xmenu loading faster when not using icons.
+.TP
+.BI \-fn " font"
+defines the font or font set used.
+.TP
+.BI \-nb " color"
+defines the normal background color.
+.IR #RGB ,
+.IR #RRGGBB ,
+and X color names are supported.
+.TP
+.BI \-nf " color"
+defines the normal foreground color.
+.TP
+.BI \-sb " color"
+defines the selected background color.
+.TP
+.BI \-sf " color"
+defines the selected foreground color.
+.TP
+.BI \-bc " color"
+defines the border color.
+.TP
+.BI \-sp " color"
+defines the separator color.
 .TP
 .BI -p " position"
 Set the position to spawn xmenu.

--- a/xmenu.c
+++ b/xmenu.c
@@ -137,8 +137,9 @@ arg_parse(int argc, char *argv[])
 			iflag = 1;
 		} else if (!strcmp(argv[i], "-w")) {
 			wflag = 1;
-		} else {
-			return (-1);
+		} else if (argv[i][0] == '-' && strlen(argv[i]) > 1) {
+			fprintf(stderr, "%s: invalid option -- '%c'\n", argv[0], argv[i][1]);
+			usage();
 		}
 	}
 	return (i);
@@ -1331,6 +1332,6 @@ cleanup(void)
 static void
 usage(void)
 {
-	(void)fprintf(stderr, "usage: xmenu [-iw] [-p position] [title]\n");
+	(void)fprintf(stderr, "usage: xmenu [-iw] [-p position] [-fn font] [-nb color] [-nf color] [-sb color] [-sf color] [-bc color] [-sp color] [title]\n");
 	exit(1);
 }

--- a/xmenu.c
+++ b/xmenu.c
@@ -109,35 +109,52 @@ static int wflag = 0;   /* whether to let the window manager control XMenu */
  * Function implementations
  */
 
+/* arrgument parser implementation to have dmenu style arguments */
+int
+arg_parse(int argc, char *argv[])
+{
+	int i = 1;
+
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "-fn")) {
+			config.font = argv[++i];
+		} else if (!strcmp(argv[i], "-nb")) {
+			config.background_color = argv[++i];
+		} else if (!strcmp(argv[i], "-nf")) {
+			config.foreground_color = argv[++i];
+		} else if (!strcmp(argv[i], "-sb")) {
+			config.selbackground_color = argv[++i];
+		} else if (!strcmp(argv[i], "-sf")) {
+			config.selforeground_color = argv[++i];
+		} else if (!strcmp(argv[i], "-bc")) {
+			config.border_color = argv[++i];
+		} else if (!strcmp(argv[i], "-sp")) {
+			config.separator_color = argv[++i];
+		} else if (!strcmp(argv[i], "-p")) {
+			pflag = 1;
+			parseposition(argv[++i]);
+		} else if (!strcmp(argv[i], "-i")) {
+			iflag = 1;
+		} else if (!strcmp(argv[i], "-w")) {
+			wflag = 1;
+		} else {
+			return (-1);
+		}
+	}
+	return (i);
+}
+
 /* xmenu: generate menu from stdin and print selected entry to stdout */
 int
 main(int argc, char *argv[])
 {
 	struct Menu *rootmenu;
 	XClassHint classh;
-	int ch;
+	int ch = arg_parse(argc, argv);
 
-	while ((ch = getopt(argc, argv, "ip:w")) != -1) {
-		switch (ch) {
-		case 'i':
-			iflag = 1;
-			break;
-		case 'p':
-			pflag = 1;
-			parseposition(optarg);
-			break;
-		case 'w':
-			wflag = 1;
-			break;
-		default:
-			usage();
-			break;
-		}
-	}
-	argc -= optind;
-	argv += optind;
-
-	if (argc > 1)
+	argc -= ch;
+	argv += ch;
+	if (argc > 1 || ch < 0)
 		usage();
 
 	/* open connection to server and set X variables */


### PR DESCRIPTION
# dmenu argment parser for styling
I added a dmenu style argument parser to change the font, the color of background and foreground during selection and in normal mode. Edited the usage and man page accordingly. I also kept the same error messages as getopt and keeps the title logic at the end if needed.

## Example
```
./xmenu -fn "Hack Nerd Font:size=13:" -nb "#393939" -nf "#bbbbbb" -sb "#50fa7b" -sf "#393939" -bc "#393939"
```
![screenshot](https://leosmith.xyz/assets/xmenu_scrot.png)

## Usage
 - **fn font** defines the font or font set used.
 - **nb color** defines the normal background color.  #RGB, #RRGGBB, and X color names are supported.
 - **nf color** defines the normal foreground color.
 - **sb color** defines the selected background color.
 - **sf color** defines the selected foreground color.
 - **bc color** defines the border color.
 - **sp color** defines the separator color.
