### PR TITLE
Improved Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include config.mk
 
+DESTDIR ?= /
+
 SRCS = ${PROG}.c
 OBJS = ${SRCS:.c=.o}
 
@@ -17,10 +19,8 @@ clean:
 	-rm ${OBJS} ${PROG}
 
 install: all
-	mkdir -p ${DESTDIR}${PREFIX}/bin
-	install -m 755 ${PROG} ${DESTDIR}${PREFIX}/bin/${PROG}
-	mkdir -p ${DESTDIR}${MANPREFIX}/man1
-	install -m 644 ${PROG}.1 ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
+	install -D -m 755 ${PROG} ${DESTDIR}${PREFIX}/bin/${PROG}
+	install -D -m 644 ${PROG}.1 ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/${PROG}

--- a/config.mk
+++ b/config.mk
@@ -2,16 +2,16 @@
 PROG = xmenu
 
 # paths
-PREFIX    ?= /usr/local
+PREFIX    ?= ${DESTDIR}/usr/local
 MANPREFIX ?= ${PREFIX}/share/man
 
-LOCALINC ?= /usr/local/include
-LOCALLIB ?= /usr/local/lib
+LOCALINC ?= ${DESTDIR}/usr/local/include
+LOCALLIB ?= ${DESTDIR}/usr/local/lib
 
-X11INC ?= /usr/X11R6/include
-X11LIB ?= /usr/X11R6/lib
+X11INC ?= ${DESTDIR}/usr/X11R6/include
+X11LIB ?= ${DESTDIR}/usr/X11R6/lib
 
-FREETYPEINC ?= /usr/include/freetype2
+FREETYPEINC ?= ${DESTDIR}/usr/include/freetype2
 # OpenBSD (uncomment)
 #FREETYPEINC = ${X11INC}/freetype2
 


### PR DESCRIPTION
Added `DESTIR` variable needed to be included in many distro package manager scripts that build and install packages. See [here](https://www.gnu.org/prep/standards/html_node/DESTDIR.html) for more details. `install` has a `-D` flag to make the directories as needed, preventing redundancy over changes. This is all I can really think of at the moment. For other standards that should probably be followed, see [GNU Coding Standards - Release Process](https://www.gnu.org/prep/standards/standards.html#Managing-Releases), and something that's probably more relavent, see [GNU Coding Standards - Makefile Conventions](https://www.gnu.org/prep/standards/standards.html#Managing-Releases). I'm still learning about Makefiles and package management myself, so I thought I'd link stuff I found helpful. I'll keep an eye out if I messed up. Cheers ~