### PR TITLE
Make standard for non-GNU

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -8,6 +8,9 @@ MANPREFIX ?= ${PREFIX}/share/man
 LOCALINC ?= /usr/local/include
 LOCALLIB ?= /usr/local/lib
 
+# SHELL variable (mainly for non-GNU make)
+SHELL ?= /bin/sh
+
 X11INC ?= /usr/X11R6/include
 X11LIB ?= /usr/X11R6/lib
 


### PR DESCRIPTION
[Here](https://github.com/phillbush/xmenu/pull/19) there seems to be interest in making this app as portable as possible. If that's the case, the `SHELL` variable really should be set "to avoid trouble on systems where the `SHELL` variable might be inherited from the environment" ([GNU Makefile Basics](https://www.gnu.org/prep/standards/html_node/Makefile-Basics.html)). On GNU's Makefile basics, it states:
> Every Makefile should contain this line: 
> ```
> SHELL = /bin/sh
> ```
While this isn't really required on GNU's version of Make, and thus you don't see it on GNU / Linux apps as often, this is a good practice especially when dealing with non-GNU versions of Make. This also isn't necessarily a bad idea to include on GNU version of Make as well.