### PR TITLE
Include Xinerama header dep in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The files are:
 
 First, edit `./config.mk` to match your local setup.
 
-In order to build XMenu you need the `Imlib2`, `Xlib` and `Xft` header files.
+In order to build XMenu you need the `Imlib2`, `Xlib`, `Xinerama` and `Xft` header files.
 The default configuration for XMenu is specified in the file `config.h`,
 you can edit it, but most configuration can be changed at runtime via
 X resources.  Enter the following command to build XMenu.  This command


### PR DESCRIPTION
On line 16 of `xmenu.c`
```c
#include <X11/extensions/Xinerama.h>
```
This is an X11 extension mainly for multi-mointor, widely packaged separately on distros.