### PR TITLE
Simplify DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 include config.mk
 
+bindir = ${DESTDIR}${PREFIX}
+mandir = ${DESTDIR}${MANPREFIX}
+
 SRCS = ${PROG}.c
 OBJS = ${SRCS:.c=.o}
 
@@ -17,13 +20,13 @@ clean:
 	-rm ${OBJS} ${PROG}
 
 install: all
-	mkdir -p ${DESTDIR}${PREFIX}/bin
-	install -m 755 ${PROG} ${DESTDIR}${PREFIX}/bin/${PROG}
-	mkdir -p ${DESTDIR}${MANPREFIX}/man1
-	install -m 644 ${PROG}.1 ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
+	mkdir -p ${bindir}/bin
+	install -m 755 ${PROG} ${bindir}/bin/${PROG}
+	mkdir -p ${mandir}/man1
+	install -m 644 ${PROG}.1 ${mandir}/man1/${PROG}.1
 
 uninstall:
-	rm -f ${DESTDIR}${PREFIX}/bin/${PROG}
-	rm -f ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
+	rm -f ${bindir}/bin/${PROG}
+	rm -f ${mandir}/man1/${PROG}.1
 
 .PHONY: all clean install uninstall


### PR DESCRIPTION
You can include DESTDIR when you define PATH, and everything will inherit it - no need to include DESTDIR repeatedly.