### PR TITLE
Flush stdout in `run()`, in case it has been redirected

### DIFF
--- a/xmenu.c
+++ b/xmenu.c
@@ -1662,6 +1662,7 @@ enteritem:
 					currmenu = item->submenu;
 				} else {
 					printf("%s\n", item->output);
+					fflush(stdout);
 					goto done;
 				}
 				select = currmenu->list;


### PR DESCRIPTION
Calling `fflush` in `run` avoids certain cases where standard output isn't line-buffered. See #42 