### PR TITLE
Handle boundary crossing for fixed positioning

### DIFF
--- a/xmenu.c
+++ b/xmenu.c
@@ -943,12 +943,12 @@ setupmenupos(struct Menu *menu, struct Monitor *mon)
 	width = menu->w + config.border_pixels * 2;
 	height = menu->h + config.border_pixels * 2;
 	if (menu->parent == NULL) { /* if root menu, calculate in respect to cursor */
-		if (pflag || (config.posx >= mon->x && mon->x + mon->w - config.posx >= width))
+		if ((pflag || (config.posx >= mon->x)) && mon->x + mon->w - config.posx >= width)
 			menu->x = config.posx;
 		else if (config.posx > width)
 			menu->x = config.posx - width;
 
-		if (pflag || (config.posy >= mon->y && mon->y + mon->h - config.posy >= height))
+		if ((pflag || (config.posy >= mon->y)) && mon->y + mon->h - config.posy >= height)
 			menu->y = config.posy;
 		else if (mon->y + mon->h > height)
 			menu->y = mon->y + mon->h - height;


### PR DESCRIPTION
This is so that you can position your menu in, say, the upper right corner of your screen without the menu being rendered outside of the screen. For example on a monitor that is 2560 by 1080 pixel, using the -p 2560x0 will now render the menu inside the screen. The same goes for the y-axis when using -p 2560x1080.

I think this could be a useful feature as I see no reason to handle the pflag differently when it comes to boundary crossing checks. I hope I have not missed some other intention for this difference.