### PR TITLE
Remove POSIX def and add missing X11 libs to fix building on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ LOCALLIB = /usr/local/lib
 X11INC = /usr/X11R6/include
 X11LIB = /usr/X11R6/lib
 
-DEFS = -D_POSIX_C_SOURCE=200809L -DGNU_SOURCE -D_BSD_SOURCE
+DEFS = -D_GNU_SOURCE -D_BSD_SOURCE
 INCS = -I${LOCALINC} -I${X11INC} -I/usr/include/freetype2 -I${X11INC}/freetype2
-LIBS = -L${LOCALLIB} -L${X11LIB} -lfontconfig -lXft -lX11 -lXinerama -lXrender -lImlib2
+LIBS = -L${LOCALLIB} -L${X11LIB} -lfontconfig -lfreetype -lXft -lX11 -lXinerama -lXrender -lxcb -lxcb-shm -lXext -lImlib2
 
 bindir = ${DESTDIR}${PREFIX}/bin
 mandir = ${DESTDIR}${MANPREFIX}/man1


### PR DESCRIPTION
`_POSIX_C_SOURCE=200809L` is causing both GCC 13 and Clang 15 throw `strcasestr` undeclared error.
```
xmenu.c:801:5: error: call to undeclared function 'strcasestr'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                                strcasestr(value, "ENABLED") != NULL
                                ^
```

Imlib2 is usually not installed in standard library paths but in Homebrew or MacPorts so I think there's no need to add them, just set the necessary `CFLAGS` and `LDFLAGS`.
```
make CFLAGS=-I/opt/homebrew/opt/imlib2/include LDFLAGS=-L/opt/homebrew/opt/imlib2/lib
```